### PR TITLE
HotFix-WEBAPP-760-Moving-BPConfig-To-Secrets

### DIFF
--- a/stacks/connected_cloud.py
+++ b/stacks/connected_cloud.py
@@ -152,7 +152,8 @@ class BasepairConnectedCloud(Stack):
                 "partner.basepair.ec2": self._get_ec2_assume_role_policy(),
                 "partner.basepair.iam": self._get_iam_assume_role_policy(),
                 "partner.basepair.omics": self._get_omics_storage_policy(),
-                "partner.basepair.s3": self._get_s3_policy()
+                "partner.basepair.s3": self._get_s3_policy(),
+                "partner.basepair.sm": self._get_sm_create_policy(),
             }
         )
 
@@ -264,6 +265,26 @@ class BasepairConnectedCloud(Stack):
                     ],
                     effect=iam.Effect.ALLOW,
                     sid="AllowS3"
+                )
+            ]
+        )
+
+    def _get_sm_create_policy(self):
+        return iam.PolicyDocument(
+            statements=[
+                iam.PolicyStatement(
+                    actions=[
+                        "secretsmanager:CreateSecret",
+                        "secretsmanager:TagResource",
+                    ],
+                    conditions={
+                        "StringLike": {
+                            "aws:ResourceTag/ID": "worker_secrets_*"
+                        }
+                    },
+                    effect=iam.Effect.ALLOW,
+                    resources=["*"],
+                    sid="AllowSM"
                 )
             ]
         )

--- a/stacks/connected_cloud.py
+++ b/stacks/connected_cloud.py
@@ -24,7 +24,7 @@ class BasepairConnectedCloud(Stack):
 
     def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
-        
+
         iam.CfnServiceLinkedRole(
             self,
             "SpotInstanceServiceLinkedRole",
@@ -165,7 +165,8 @@ class BasepairConnectedCloud(Stack):
             role_name="partner.basepair.worker",
             inline_policies={
                 "basepair.ecr": self._get_basepair_ecr_policy(),
-                "partner.basepair.s3": self._get_s3_policy()
+                "partner.basepair.s3": self._get_s3_policy(),
+                "partner.basepair.sm": self._get_sm_policy(),
             }
         )
 
@@ -263,6 +264,26 @@ class BasepairConnectedCloud(Stack):
                     ],
                     effect=iam.Effect.ALLOW,
                     sid="AllowS3"
+                )
+            ]
+        )
+
+    def _get_sm_policy(self):
+        return iam.PolicyDocument(
+            statements=[
+                iam.PolicyStatement(
+                    actions=[
+                        "secretsmanager:GetSecretValue",
+                        "secretsmanager:DeleteSecret",
+                    ],
+                    conditions={
+                        "StringLike": {
+                            "aws:ResourceTag/ID": "worker_secrets_*"
+                        }
+                    },
+                    effect=iam.Effect.ALLOW,
+                    resources=["*"],
+                    sid="AllowSM"
                 )
             ]
         )


### PR DESCRIPTION
## Motivation
We are sending many secrets through the user data when we initialise ec2 for analysis. This cause one know issue related with large user data making the EC2 request to be denied by AWS.
The other issues are related with security because the secrets get expose in logs and in the user data.

## How this PR implement the fix?
We move the secrets to aws secret manager so we only use the user data to retrieve and delete the secret reducing the amount of data we put in the user data.

## Requires
- https://github.com/basepair/infra/pull/55
- https://github.com/basepair/basepair-python/pull/162
- https://github.com/basepair/webapp/pull/2258

## Todo:
- [ ] Test common setup.
- [ ] Test cross aws setup.