### PR TITLE
Added Option in cdk to deploy with and without healthomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,15 @@ App->>User: Display Results
    cdk deploy \
        --parameters BasepairAccountId=<Basepair Account Id> \
        --parameters BasepairRoleName=<Basepair Role Name> \
+       -c deploy_with_omics=<"Yes/No"> \
+       -c create_spot_service_linked_role=<"Yes/No"> \
        --require-approval never \ 
        --outputs-file cdk.out.json
    ```
+   Note:
+   * Set deploy_with_omics Yes if you want Connected cloud with omics by default it is set to No.
+   * Set create_spot_service_linked_role Yes if you dont have `AWSServiceRoleForEC2Spot` role.
+
 3. After the above command is successfully completed, Please share the `cdk.out.json` file with Basepair Team
 4. For any support, please reach out to Basepair Team
 


### PR DESCRIPTION
## Motivation
Current cdk code is trying to deploy with Healthomics. We need to add option if they want the Connected Cloud setup with or without Healthomics. Also, `AWSServiceRoleForEC2Spot` role might be already present on some aws account depending if they have ever used spot related service so the cdk was raising expection if the role was already present.

## How this PR address the change?
We have added two inputs from user `deploy_with_omics`, `create_spot_service_linked_role` so that the user can choose depending on their requirements.